### PR TITLE
Support Google Keep JSON Import, Note Deduplication, and XML/Encoding Fixes

### DIFF
--- a/src/config/formats.js
+++ b/src/config/formats.js
@@ -86,7 +86,7 @@ export function detectFormat(mainFilename, fileList = []) {
         throw new Error("Gzip (.tgz) archives are not supported. Please use standard .zip files.");
     }
 
-    // 2. Hard Matches for single files
+    // 2. Single-file hard matches
     if (fileList.length <= 1) {
         if (ext === 'enex') return 'enex';
         if (ext === 'json') return 'json';
@@ -94,7 +94,7 @@ export function detectFormat(mainFilename, fileList = []) {
         if (ext === 'html' || ext === '_keep') return 'keep';
     }
 
-    // 3. Batch / Zip Scanning
+    // 3. Batch / zip scanning
     const hasHtml = fileList.some(f => f.endsWith('.html'));
     const hasJson = fileList.some(f => f.endsWith('.json'));
     const hasMd = fileList.some(f => f.endsWith('.md'));
@@ -103,16 +103,18 @@ export function detectFormat(mainFilename, fileList = []) {
 
     if (hasMd && hasCsv) return 'notion';
     if (hasEnex) return 'enex';
-    
-    // Check if Google Keep Takeout
-    // Keep takeout contains HTML/JSON notes, and often a "Keep" folder or "archive_browser.html"
-    const hasKeepPath = fileList.some(f => f.toLowerCase().includes('keep/') || f.toLowerCase().includes('keep\\'));
-    const hasArchiveBrowser = fileList.some(f => f.includes('archive_browser.html'));
-    
-    if (hasKeepPath || hasArchiveBrowser) return 'keep';
-    if (hasHtml && !hasMd) return 'keep';
-    if (hasJson && !hasMd) return 'keep';
+
+    // Google Keep Takeout: notes plus a Keep/ folder or the archive_browser.html index.
+    const keepIndicator = fileList.some(f => {
+        const lower = f.toLowerCase();
+        return lower.includes('keep/') || lower.includes('keep\\') || lower.includes('archive_browser.html');
+    });
+    if (keepIndicator) return 'keep';
+
+    // HTML batches default to Keep (most common); JSON-only batches are ambiguous
+    // and must NOT be assumed Keep without a marker.
+    if (hasHtml) return 'keep';
     if (hasMd) return 'markdown';
-    
+
     return 'unknown';
 }

--- a/src/config/formats.js
+++ b/src/config/formats.js
@@ -86,22 +86,33 @@ export function detectFormat(mainFilename, fileList = []) {
         throw new Error("Gzip (.tgz) archives are not supported. Please use standard .zip files.");
     }
 
-    // 2. Hard Matches
-    if (ext === 'enex') return 'enex';
-    if (ext === 'json' && fileList.length <= 1) return 'json';
-    if (ext === 'md') return 'markdown';
-    if (ext === 'html' || ext === '_keep') return 'keep';
-
-    // 3. Zip Content Scanning
-    if (ext === 'zip') {
-        const hasHtml = fileList.some(f => f.endsWith('.html'));
-        const hasMd = fileList.some(f => f.endsWith('.md'));
-        const hasCsv = fileList.some(f => f.endsWith('.csv'));
-        
-        if (hasMd && hasCsv) return 'notion';
-        if (hasHtml) return 'keep'; // Google Takeout is mostly HTMLs
-        return 'markdown'; // Default zip assumption
+    // 2. Hard Matches for single files
+    if (fileList.length <= 1) {
+        if (ext === 'enex') return 'enex';
+        if (ext === 'json') return 'json';
+        if (ext === 'md') return 'markdown';
+        if (ext === 'html' || ext === '_keep') return 'keep';
     }
+
+    // 3. Batch / Zip Scanning
+    const hasHtml = fileList.some(f => f.endsWith('.html'));
+    const hasJson = fileList.some(f => f.endsWith('.json'));
+    const hasMd = fileList.some(f => f.endsWith('.md'));
+    const hasCsv = fileList.some(f => f.endsWith('.csv'));
+    const hasEnex = fileList.some(f => f.endsWith('.enex'));
+
+    if (hasMd && hasCsv) return 'notion';
+    if (hasEnex) return 'enex';
+    
+    // Check if Google Keep Takeout
+    // Keep takeout contains HTML/JSON notes, and often a "Keep" folder or "archive_browser.html"
+    const hasKeepPath = fileList.some(f => f.toLowerCase().includes('keep/') || f.toLowerCase().includes('keep\\'));
+    const hasArchiveBrowser = fileList.some(f => f.includes('archive_browser.html'));
+    
+    if (hasKeepPath || hasArchiveBrowser) return 'keep';
+    if (hasHtml && !hasMd) return 'keep';
+    if (hasJson && !hasMd) return 'keep';
+    if (hasMd) return 'markdown';
     
     return 'unknown';
 }

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,8 @@ const state = {
     selectedIds: new Set(), // Format: "sourceIndex:path"
     worker: new Worker(new URL('./modules/worker.js', import.meta.url), { type: 'module' }),
     isProcessing: false,
-    detectedFormat: null
+    detectedFormat: null,
+    keepJsonPaths: new Set() // .json note paths, used to dedupe Keep HTML/JSON pairs
 };
 
 // --- DOM ELEMENTS ---
@@ -271,27 +272,11 @@ function finalizeBatch(sourceIndex, entries) {
     const allNames = state.allEntries.map(e => e.name);
     const primaryName = state.allEntries.length > 0 ? state.allEntries[0].name : 'unknown';
     state.detectedFormat = detectFormat(primaryName, allNames);
+    recomputeKeepJsonPaths();
 
     // Auto-Select ONLY Visible Files
-    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
     taggedEntries.forEach(e => {
-        let isVisible = false;
-        if (!e.name.startsWith('.')) {
-            if (isImage(e.name)) isVisible = true;
-            else if (state.detectedFormat === 'keep') {
-                if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
-                    isVisible = true;
-                } else if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
-                    const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
-                    if (!jsonPaths.has(correspondingJson)) isVisible = true;
-                }
-            }
-            else if (state.detectedFormat === 'markdown' && e.name.endsWith('.md')) isVisible = true;
-            else if (state.detectedFormat === 'enex' && e.name.endsWith('.enex')) isVisible = true;
-            else if (state.detectedFormat === 'json' && e.name.endsWith('.json')) isVisible = true;
-            else if (state.detectedFormat === 'unknown') isVisible = true;
-        }
-        if (isVisible) {
+        if (isVisibleEntry(e)) {
             state.selectedIds.add(`${sourceIndex}:${e.path}`);
         }
     });
@@ -305,30 +290,8 @@ function finalizeBatch(sourceIndex, entries) {
 function renderList() {
     els.fileList.innerHTML = '';
     
-    // Filter view based on detected format + Images
-    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
-    const displayEntries = state.allEntries.filter(e => {
-        if (e.name.startsWith('.')) return false;
-        
-        const isImg = isImage(e.name);
-        if (isImg) return true; // Always show images if they were accepted
-
-        if (state.detectedFormat === 'keep') {
-            if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
-                return true;
-            }
-            if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
-                const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
-                return !jsonPaths.has(correspondingJson);
-            }
-            return false;
-        }
-        if (state.detectedFormat === 'markdown' || state.detectedFormat === 'notion') return e.name.endsWith('.md');
-        if (state.detectedFormat === 'enex') return e.name.endsWith('.enex');
-        if (state.detectedFormat === 'json') return e.name.endsWith('.json');
-        
-        return true; 
-    });
+    // Filter view based on detected format + Images (single source of truth)
+    const displayEntries = state.allEntries.filter(isVisibleEntry);
 
     if (displayEntries.length === 0 && state.allEntries.length > 0) {
         els.fileList.innerHTML = `<div style="text-align:center; padding:30px; color:var(--sub)">No compatible notes found.</div>`;
@@ -402,25 +365,7 @@ function toggleSelectAll() {
     // Since we don't store ID in DOM, we rely on state sync.
     // Let's re-calculate visible IDs.
     
-    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
-    const visibleEntries = state.allEntries.filter(e => {
-        if (e.name.startsWith('.')) return false;
-        if (isImage(e.name)) return true;
-        if (state.detectedFormat === 'keep') {
-            if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
-                return true;
-            }
-            if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
-                const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
-                return !jsonPaths.has(correspondingJson);
-            }
-            return false;
-        }
-        if (state.detectedFormat === 'markdown') return e.name.endsWith('.md');
-        if (state.detectedFormat === 'enex') return e.name.endsWith('.enex');
-        if (state.detectedFormat === 'json') return e.name.endsWith('.json');
-        return true;
-    });
+    const visibleEntries = state.allEntries.filter(isVisibleEntry);
 
     if (shouldSelect) {
         visibleEntries.forEach(e => {
@@ -544,11 +489,9 @@ async function finishConversion(contentMap, binaryMap, dateMap = {}) {
             try {
                 let note = null;
                 if (source === 'keep') {
-                    if (path.endsWith('.json')) {
-                        note = parseKeepJson(content);
-                    } else {
-                        note = parseKeepHtml(content);
-                    }
+                    // Keep Takeout ships .json notes alongside .html; JSON carries
+                    // richer data (tags, checkboxes, microsec timestamps).
+                    note = path.endsWith('.json') ? parseKeepJson(content) : parseKeepHtml(content);
                 }
                 else if (source === 'enex') note = parseEnex(content);
                 else if (source === 'markdown') note = fromMarkdown(content);
@@ -662,28 +605,29 @@ async function generateEnexWithResources(notes, binaryMap) {
             }
         }
         
-        content = content.replace(/<input[^>]*type="checkbox"[^>]*checked="true"[^>]*\/?>/gi, '<en-todo checked="true"/>');
-        content = content.replace(/<input[^>]*type="checkbox"[^>]*checked[^>]*\/?>/gi, '<en-todo checked="true"/>');
-        content = content.replace(/<input[^>]*type="checkbox"[^>]*\/?>/gi, '<en-todo/>');
+        // Map checkbox inputs to Evernote <en-todo> items, matching any quote style.
+        content = content.replace(/<input\b[^>]*?\btype\s*=\s*["']?checkbox["']?[^>]*?\bchecked\b[^>]*\/?>/gi, '<en-todo checked="true"/>');
+        content = content.replace(/<input\b[^>]*?\btype\s*=\s*["']?checkbox["']?[^>]*\/?>/gi, '<en-todo/>');
         content = content.replace(/<br>/g, '<br/>');
         content = content.replace(/<img[^>]*>/gi, '');
         
         const title = (note.title || 'Untitled').replace(/[<>&'"]/g, c => {
             switch(c){case '<':return '&lt;';case '>':return '&gt;';case '&':return '&amp;';case "'":return '&apos;';case '"':return '&quot;';}
         });
+
+        // Preserve Keep labels as ENEX <tag> nodes, escaping XML entities.
+        let tagsXml = '';
+        if (Array.isArray(note.tags)) {
+            note.tags.forEach(t => {
+                const cleanTag = (t || '').replace(/[<>&'"]/g, c => {
+                    switch(c){case '<':return '&lt;';case '>':return '&gt;';case '&':return '&amp;';case "'":return '&apos;';case '"':return '&quot;';}
+                });
+                tagsXml += `\n  <tag>${cleanTag}</tag>`;
+            });
+        }
         
         const createdTs = toEnexDate(note.created) || ts;
         const updatedTs = toEnexDate(note.updated) || createdTs;
-
-        let tagsXml = '';
-        if (note.tags && Array.isArray(note.tags)) {
-            note.tags.forEach(t => {
-                const cleanTag = t.replace(/[<>&'"]/g, c => {
-                    switch(c){case '<':return '&lt;';case '>':return '&gt;';case '&':return '&amp;';case "'":return '&apos;';case '"':return '&quot;';}
-                });
-                tagsXml += `  <tag>${cleanTag}</tag>\n`;
-            });
-        }
 
         xml += `
 <note>
@@ -692,84 +636,108 @@ async function generateEnexWithResources(notes, binaryMap) {
 <!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
 <en-note>${content}</en-note>]]></content>
   <created>${createdTs}</created>
-  <updated>${updatedTs}</updated>
-  ${tagsXml}  ${resourcesXml}
+  <updated>${updatedTs}</updated>${tagsXml}
+  ${resourcesXml}
 </note>`;
     }
     xml += `\n</en-export>`;
     return xml;
 }
 
+// --- UTILS ---
+
+function isImage(name) {
+    return /\.(jpg|jpeg|png|gif|webp)$/i.test(name);
+}
+
+// Escape &, <, > for safe HTML interpolation.
+function escapeHtml(str) {
+    return String(str == null ? '' : str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+// Cache of .json note paths, used to hide duplicate Keep HTML/JSON pairs.
+function recomputeKeepJsonPaths() {
+    state.keepJsonPaths = new Set(
+        state.allEntries.filter(e => e.name.endsWith('.json')).map(e => e.path)
+    );
+}
+
+// Single source of truth for which entries show and auto-select in the file list.
+function isVisibleEntry(e) {
+    if (e.name.startsWith('.')) return false;
+    if (isImage(e.name)) return true;
+    const fmt = state.detectedFormat;
+    if (fmt === 'keep') {
+        // Skip the Takeout navigation page.
+        if (e.name.toLowerCase() === 'archive_browser.html') return false;
+        if (e.name.endsWith('.json')) return true;
+        if (e.name.endsWith('.html')) {
+            // Prefer the JSON copy when both exist for the same note.
+            const jsonSibling = e.path.slice(0, -5) + '.json';
+            return !state.keepJsonPaths.has(jsonSibling);
+        }
+        return false;
+    }
+    if (fmt === 'markdown' || fmt === 'notion') return e.name.endsWith('.md');
+    if (fmt === 'enex') return e.name.endsWith('.enex');
+    if (fmt === 'json') return e.name.endsWith('.json');
+    return true; // unknown format: show everything
+}
+
+// Parse Google Keep's native JSON export into an internal note object.
 function parseKeepJson(content) {
     const data = JSON.parse(content);
-    
-    // Map textContent or listContent to content (HTML string)
     let htmlContent = '';
-    if (data.listContent && Array.isArray(data.listContent)) {
+
+    if (Array.isArray(data.listContent)) {
+        // Checklist: render items as HTML checkboxes (escaped).
         htmlContent = '<ul>';
         data.listContent.forEach(item => {
             const checkedAttr = item.isChecked ? ' checked="true"' : '';
-            htmlContent += `<li><input type="checkbox"${checkedAttr}/> ${item.text || ''}</li>`;
+            htmlContent += `<li><input type="checkbox"${checkedAttr}/> ${escapeHtml(item.text)}</li>`;
         });
         htmlContent += '</ul>';
     } else if (data.textContent) {
-        // Convert text content: escape HTML, replace newlines with <br/>
-        const escaped = (data.textContent || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-        htmlContent = escaped.replace(/\n/g, '<br/>');
+        // Plain text note: escape HTML, convert newlines to <br/>.
+        htmlContent = escapeHtml(data.textContent).replace(/\n/g, '<br/>');
     }
 
-    // Map labels to tags
+    // Map Keep labels -> tags.
     const tags = [];
-    if (data.labels && Array.isArray(data.labels)) {
-        data.labels.forEach(l => {
-            if (l.name) tags.push(l.name);
-        });
+    if (Array.isArray(data.labels)) {
+        data.labels.forEach(l => { if (l.name) tags.push(l.name); });
     }
 
-    // Map attachments
+    // Map attachments (Keep uses lowercase "filepath" in some export versions).
     const attachments = [];
-    if (data.attachments && Array.isArray(data.attachments)) {
+    if (Array.isArray(data.attachments)) {
         data.attachments.forEach(att => {
-            if (att.filePath) {
-                attachments.push({
-                    filePath: att.filePath,
-                    mimeType: att.mimetype || 'image/jpeg'
-                });
+            const filePath = att.filePath || att.filepath || '';
+            if (filePath) {
+                attachments.push({ filePath, mimeType: att.mimetype || 'image/jpeg' });
             }
         });
     }
 
-    // Map dates (microseconds timestamps to ISO string)
-    let created = null;
-    let updated = null;
-    if (data.createdTimestampUsec) {
-        created = new Date(data.createdTimestampUsec / 1000).toISOString();
-    }
-    if (data.userEditedTimestampUsec) {
-        updated = new Date(data.userEditedTimestampUsec / 1000).toISOString();
-    }
+    // Microsecond timestamps -> ISO strings.
+    const created = data.createdTimestampUsec ? new Date(data.createdTimestampUsec / 1000).toISOString() : null;
+    const updated = data.userEditedTimestampUsec ? new Date(data.userEditedTimestampUsec / 1000).toISOString() : null;
 
     return {
         title: data.title || '',
         content: htmlContent,
         textContent: data.textContent || '',
-        tags: tags,
-        created: created,
-        updated: updated,
+        tags,
+        created,
+        updated,
         isArchived: !!data.isArchived,
         isPinned: !!data.isPinned,
         isTrashed: !!data.isTrashed,
-        attachments: attachments
+        attachments
     };
-}
-
-// --- UTILS ---
-
-function isImage(name) {
-    return /\.(jpg|jpeg|png|gif|webp)$/i.test(name);
 }
 
 // Convert any parseable date string to Evernote's compact UTC format

--- a/src/main.js
+++ b/src/main.js
@@ -273,11 +273,19 @@ function finalizeBatch(sourceIndex, entries) {
     state.detectedFormat = detectFormat(primaryName, allNames);
 
     // Auto-Select ONLY Visible Files
+    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
     taggedEntries.forEach(e => {
         let isVisible = false;
         if (!e.name.startsWith('.')) {
             if (isImage(e.name)) isVisible = true;
-            else if (state.detectedFormat === 'keep' && e.name.endsWith('.html')) isVisible = true;
+            else if (state.detectedFormat === 'keep') {
+                if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
+                    isVisible = true;
+                } else if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
+                    const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
+                    if (!jsonPaths.has(correspondingJson)) isVisible = true;
+                }
+            }
             else if (state.detectedFormat === 'markdown' && e.name.endsWith('.md')) isVisible = true;
             else if (state.detectedFormat === 'enex' && e.name.endsWith('.enex')) isVisible = true;
             else if (state.detectedFormat === 'json' && e.name.endsWith('.json')) isVisible = true;
@@ -298,13 +306,23 @@ function renderList() {
     els.fileList.innerHTML = '';
     
     // Filter view based on detected format + Images
+    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
     const displayEntries = state.allEntries.filter(e => {
         if (e.name.startsWith('.')) return false;
         
         const isImg = isImage(e.name);
         if (isImg) return true; // Always show images if they were accepted
 
-        if (state.detectedFormat === 'keep') return e.name.endsWith('.html');
+        if (state.detectedFormat === 'keep') {
+            if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
+                return true;
+            }
+            if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
+                const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
+                return !jsonPaths.has(correspondingJson);
+            }
+            return false;
+        }
         if (state.detectedFormat === 'markdown' || state.detectedFormat === 'notion') return e.name.endsWith('.md');
         if (state.detectedFormat === 'enex') return e.name.endsWith('.enex');
         if (state.detectedFormat === 'json') return e.name.endsWith('.json');
@@ -384,10 +402,20 @@ function toggleSelectAll() {
     // Since we don't store ID in DOM, we rely on state sync.
     // Let's re-calculate visible IDs.
     
+    const jsonPaths = new Set(state.allEntries.filter(e => e.path.endsWith('.json')).map(e => e.path));
     const visibleEntries = state.allEntries.filter(e => {
         if (e.name.startsWith('.')) return false;
         if (isImage(e.name)) return true;
-        if (state.detectedFormat === 'keep') return e.name.endsWith('.html');
+        if (state.detectedFormat === 'keep') {
+            if (e.name.endsWith('.json') && e.name !== 'archive_browser.html') {
+                return true;
+            }
+            if (e.name.endsWith('.html') && e.name !== 'archive_browser.html') {
+                const correspondingJson = e.path.substring(0, e.path.length - 5) + '.json';
+                return !jsonPaths.has(correspondingJson);
+            }
+            return false;
+        }
         if (state.detectedFormat === 'markdown') return e.name.endsWith('.md');
         if (state.detectedFormat === 'enex') return e.name.endsWith('.enex');
         if (state.detectedFormat === 'json') return e.name.endsWith('.json');
@@ -515,7 +543,13 @@ async function finishConversion(contentMap, binaryMap, dateMap = {}) {
         Object.entries(contentMap).forEach(([path, content]) => {
             try {
                 let note = null;
-                if (source === 'keep') note = parseKeepHtml(content);
+                if (source === 'keep') {
+                    if (path.endsWith('.json')) {
+                        note = parseKeepJson(content);
+                    } else {
+                        note = parseKeepHtml(content);
+                    }
+                }
                 else if (source === 'enex') note = parseEnex(content);
                 else if (source === 'markdown') note = fromMarkdown(content);
                 else if (source === 'json') note = JSON.parse(content);
@@ -628,6 +662,9 @@ async function generateEnexWithResources(notes, binaryMap) {
             }
         }
         
+        content = content.replace(/<input[^>]*type="checkbox"[^>]*checked="true"[^>]*\/?>/gi, '<en-todo checked="true"/>');
+        content = content.replace(/<input[^>]*type="checkbox"[^>]*checked[^>]*\/?>/gi, '<en-todo checked="true"/>');
+        content = content.replace(/<input[^>]*type="checkbox"[^>]*\/?>/gi, '<en-todo/>');
         content = content.replace(/<br>/g, '<br/>');
         content = content.replace(/<img[^>]*>/gi, '');
         
@@ -638,6 +675,16 @@ async function generateEnexWithResources(notes, binaryMap) {
         const createdTs = toEnexDate(note.created) || ts;
         const updatedTs = toEnexDate(note.updated) || createdTs;
 
+        let tagsXml = '';
+        if (note.tags && Array.isArray(note.tags)) {
+            note.tags.forEach(t => {
+                const cleanTag = t.replace(/[<>&'"]/g, c => {
+                    switch(c){case '<':return '&lt;';case '>':return '&gt;';case '&':return '&amp;';case "'":return '&apos;';case '"':return '&quot;';}
+                });
+                tagsXml += `  <tag>${cleanTag}</tag>\n`;
+            });
+        }
+
         xml += `
 <note>
   <title>${title}</title>
@@ -646,11 +693,77 @@ async function generateEnexWithResources(notes, binaryMap) {
 <en-note>${content}</en-note>]]></content>
   <created>${createdTs}</created>
   <updated>${updatedTs}</updated>
-  ${resourcesXml}
+  ${tagsXml}  ${resourcesXml}
 </note>`;
     }
     xml += `\n</en-export>`;
     return xml;
+}
+
+function parseKeepJson(content) {
+    const data = JSON.parse(content);
+    
+    // Map textContent or listContent to content (HTML string)
+    let htmlContent = '';
+    if (data.listContent && Array.isArray(data.listContent)) {
+        htmlContent = '<ul>';
+        data.listContent.forEach(item => {
+            const checkedAttr = item.isChecked ? ' checked="true"' : '';
+            htmlContent += `<li><input type="checkbox"${checkedAttr}/> ${item.text || ''}</li>`;
+        });
+        htmlContent += '</ul>';
+    } else if (data.textContent) {
+        // Convert text content: escape HTML, replace newlines with <br/>
+        const escaped = (data.textContent || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        htmlContent = escaped.replace(/\n/g, '<br/>');
+    }
+
+    // Map labels to tags
+    const tags = [];
+    if (data.labels && Array.isArray(data.labels)) {
+        data.labels.forEach(l => {
+            if (l.name) tags.push(l.name);
+        });
+    }
+
+    // Map attachments
+    const attachments = [];
+    if (data.attachments && Array.isArray(data.attachments)) {
+        data.attachments.forEach(att => {
+            if (att.filePath) {
+                attachments.push({
+                    filePath: att.filePath,
+                    mimeType: att.mimetype || 'image/jpeg'
+                });
+            }
+        });
+    }
+
+    // Map dates (microseconds timestamps to ISO string)
+    let created = null;
+    let updated = null;
+    if (data.createdTimestampUsec) {
+        created = new Date(data.createdTimestampUsec / 1000).toISOString();
+    }
+    if (data.userEditedTimestampUsec) {
+        updated = new Date(data.userEditedTimestampUsec / 1000).toISOString();
+    }
+
+    return {
+        title: data.title || '',
+        content: htmlContent,
+        textContent: data.textContent || '',
+        tags: tags,
+        created: created,
+        updated: updated,
+        isArchived: !!data.isArchived,
+        isPinned: !!data.isPinned,
+        isTrashed: !!data.isTrashed,
+        attachments: attachments
+    };
 }
 
 // --- UTILS ---

--- a/src/modules/worker.js
+++ b/src/modules/worker.js
@@ -41,6 +41,7 @@ self.onmessage = async (e) => {
                         if (isImage) {
                             binaryMap[path] = await entry.async('arraybuffer');
                         } else {
+                            // Decode raw bytes as UTF-8 so emoji, CJK and tag chars survive.
                             const bytes = await entry.async('uint8array');
                             contentMap[path] = new TextDecoder('utf-8').decode(bytes);
                         }

--- a/src/modules/worker.js
+++ b/src/modules/worker.js
@@ -41,7 +41,8 @@ self.onmessage = async (e) => {
                         if (isImage) {
                             binaryMap[path] = await entry.async('arraybuffer');
                         } else {
-                            contentMap[path] = await entry.async('string');
+                            const bytes = await entry.async('uint8array');
+                            contentMap[path] = new TextDecoder('utf-8').decode(bytes);
                         }
                         if (entry.date) dateMap[path] = entry.date.toISOString();
                     } catch (err) {


### PR DESCRIPTION
## Overview
This PR adds full support for importing Google Keep's native `.json` export format alongside the existing HTML format. It also implements note deduplication (prioritizing JSON files over HTML files when both are present in Google Takeout archives), maps native tags/checkboxes correctly to ENEX outputs, and fixes a character encoding issue in the zip extractor worker that caused emoji and tag corruption.

---

## Key Changes

### 1. Google Keep JSON Import Support & Auto-Deduplication
* **Format Detection Upgrade** (`src/config/formats.js`):
  * Enhanced `detectFormat` to look for folder structure indicators (e.g., `Keep/` directories) or standard Takeout indexes like `archive_browser.html` to robustly auto-detect Google Keep archives.
  * Allows matching both `.html` and `.json` files as Google Keep formats.
* **Deduplication & Filtering** (`src/main.js`):
  * When rendering lists or calculating selection state, the application now maps file paths to identify duplicate notes.
  * If a note has both a `.json` file and a `.html` file, the UI **only displays the `.json` version** to avoid importing duplicate entries.
  * Explicitly excludes system artifacts like `archive_browser.html`.
* **JSON Parser** (`src/main.js`):
  * Created `parseKeepJson(content)` to map native Google Keep schemas into internal note objects:
    * Parses checkbox lists (`listContent`) into formatted HTML checkboxes.
    * Escapes HTML characters in text notes and converts newlines to `<br/>` tags.
    * Maps labels to tags, attachments to binary paths, and microseconds timestamps (`createdTimestampUsec`, `userEditedTimestampUsec`) to ISO strings.

### 2. ENEX Export Refinement (`src/main.js`)
* **Checkbox Conversion**: Maps standard input checkbox tags (`<input type="checkbox" checked="true"/>` / `<input type="checkbox"/>`) to valid Evernote `<en-todo checked="true"/>` / `<en-todo/>` elements inside note bodies.
* **Tag Preservation**: Correctly handles note tags, escaping XML entities (like `&`, `<`, `>`, `"`, `'`) to prevent invalid ENEX document generation, and appends them as standard `<tag>Tag Name</tag>` XML nodes.

### 3. Worker UTF-8 Character Encoding Fix (`src/modules/worker.js`)
* Changed zip-extraction logic to retrieve text entries as a `uint8array` binary buffer instead of standard JSZip `string` extraction.
* Uses `TextDecoder('utf-8')` to decode the raw bytes. This ensures emojis, foreign characters, and custom tags are parsed correctly and do not suffer from character corruption.

---

## Files Changed
* [src/config/formats.js](file:///Users/schwegler/NotesMigrator/src/config/formats.js): Enhanced `detectFormat` logic to recognize Keep directories and batch structures.
* [src/main.js](file:///Users/schwegler/NotesMigrator/src/main.js): Integrated `parseKeepJson`, deduplicated list/select actions, added `<en-todo>` and `<tag>` mappings.
* [src/modules/worker.js](file:///Users/schwegler/NotesMigrator/src/modules/worker.js): Replaced JSZip string conversion with manual UTF-8 `TextDecoder` buffer parsing.

---

## Verification & Testing
* **Deduplication Check**: Uploaded a Google Takeout zip with both JSON and HTML copies of notes. Verified that only the JSON representation appears in the import list.
* **Format Check**: Verified that checkboxed lists (from Keep JSON) translate to interactive checklists in Evernote/ENEX.
* **Encoding Validation**: Imported notes containing emojis and special characters (e.g. `✨ Note Title 🏷️`) and confirmed that they render without corruption.